### PR TITLE
adding black pre-commit hook

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,67 @@
+#!/bin/sh
+#
+# This pre-commit hook will run black linting before finishing the commit.
+# If the linting has any failures (indicating a functional error) we don't commit.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, move / rename this file to .git/hooks/pre-commit.
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=4b825dc642cb6eb9a060e54bf8d69288fbee4904
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --bool hooks.allownonascii)
+
+# Redirect output to stderr.
+exec 1>&2
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<\EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+## STEP 1: Black linting should be automatically done, unless there are
+#  functional issues, then the commit is cancelled, or if the user didn't
+#  install black, they should not be using the pre-commit.
+if black --version >/dev/null 2>&1
+then
+	printf "Black is installed\n"
+        black .github/tests
+        if [ "$?" -ne "0" ]
+            then
+                printf "There was a problem with formatting, commit cancelled.\n"
+                exit 1
+        fi
+else
+	printf "Black is not installed. Install or remove hook to use it.\n"
+        exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+# exec git diff-index --check --cached $against --


### PR DESCRIPTION
This PR is adopting the pre-commit hook from buildtest https://github.com/buildtesters/buildtest/blob/devel/.github/hooks/pre-commit with slight modification to only black ``.github/tests``.

I tested this locally by copying the pre-commit to ``.git/hooks`` and it was triggering the commit as shown below.

```
(buildtest-framework) ssi29@ag-mxg-hulk090> git commit
Black is installed
reformatted /mxg-hpc/users/ssi29/schemas/.github/tests/test_organization.py
All done! ✨ 🍰 ✨
1 file reformatted, 3 files left unchanged.
[precommit_hook_black d5f436c] adding black pre-commit hook
 1 file changed, 67 insertions(+)
 create mode 100755 .github/hooks/pre-commit

```
