### PR TITLE
add compiler schema check for all fields

### DIFF
--- a/compiler/compiler-v0.0.1.schema.json
+++ b/compiler/compiler-v0.0.1.schema.json
@@ -17,7 +17,8 @@
       "type": "string"
     },
     "module": {
-      "type": "array"
+      "type": "array",
+      "items": { "type": "string" }
     },
     "compiler": {
       "type": "object",

--- a/tests/invalid/compiler/0.0.1/examples.yml
+++ b/tests/invalid/compiler/0.0.1/examples.yml
@@ -48,6 +48,17 @@ invalid_type_module:
     gnu:
       cflags: -O1
 
+module_mismatch_array_items:
+  type: compiler
+  description: "The module is an array of string items, this test as a mix of numbers and string"
+  module:
+    - 1
+    - "module purge && module load gcc/4.0"
+  compiler:
+    source: src/hello.c
+    gnu:
+      cflags: -O1
+
 missing_source_in_compiler:
   type: compiler
   description: "missing source key in compiler object"

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -75,7 +75,6 @@ def test_script_schema():
     # ensure load_recipe returns a dict object and not None
     assert isinstance(loaded, dict)
 
-    # Checking schema fields
     fields = [
         "$id",
         "$schema",
@@ -87,6 +86,7 @@ def test_script_schema():
     ]
     for field in fields:
         assert field in loaded
+    # Checking schema fields
 
     # Check individual schema properties
     assert loaded["$id"] == "%s/%s/%s" % (repo_prefix, schema_name, schema)

--- a/tests/valid/compiler/0.0.1/examples.yml
+++ b/tests/valid/compiler/0.0.1/examples.yml
@@ -12,8 +12,8 @@ hello_world_gnu:
 hello_world_intel:
   type: compiler
   module:
-   -  "module purge &&  module load intel/17"
-   -  "module purge &&  module load intel/18"
+    -  "module purge &&  module load intel/17"
+    -  "module purge &&  module load intel/18"
   compiler:
     source: src/hello.c
     intel:


### PR DESCRIPTION
fix module key in compiler, it needs to be an array of string.
Previously it was just an array and that could accept any types.
Add example for invalid module array mismatch.
Fix a tab indent in valid example hello_world_intel