### PR TITLE
update compiler schema to add 'pgi', 'cray' compiler names and

### DIFF
--- a/compiler/README.md
+++ b/compiler/README.md
@@ -1,0 +1,35 @@
+# Compiler 
+
+The compiler schema is used by buildtest to compile source files into an 
+executable. The schema supports multiple compilers, while only one can be 
+selected at a time using the `name` key. This schema is under development 
+and subject to change.
+
+# Version: 0.0.1
+
+The compiler schema is available at https://buildtesters.github.io/schemas/compiler/compiler-v0.0.1.schema.json
+
+## Global Properties
+
+| Name | Type | Description | Required for User | Default |
+| ---- | ----- | ----------- | -------------------|  -------- |
+| type | string | The schema type must be `compiler` | True |  |
+| description | string | A brief description of the test | False | |
+| module | array | A list of modules to inject into test | False | |
+| compiler | object | Define compiler setting |  True | |
+
+## Compiler Properties
+
+| Name | Type |  Description |   Required for User | Default | Choices |
+| ---- | ----- | ----------- | -------------------|  -------- | ------ |
+| name | string | Select a compiler name, based on selection buildtest will detect the appropriate compiler wrapper | True | |  gnu, intel, pgi, cray |
+| source | string | Select a source file to compile, the file could be an absolute path or relative path from Buildspec | True | | |
+| exec_args | string | Pass arguments to compiled executable |  False | | |
+| cflags | string | Pass argument to C compiler |  False | | |
+| cxxflags | string | Pass arguments to C++ compiler |  False | | |
+| fflags | string | Pass arguments to Fortran compiler |  False | | |
+| cppflags | string | Set pre-processor directives | False | | |
+| ldflags | string | Pass linker options for dynamic linking | False | | |
+
+
+ 

--- a/compiler/compiler-v0.0.1.schema.json
+++ b/compiler/compiler-v0.0.1.schema.json
@@ -23,32 +23,20 @@
     "compiler": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string",
+          "enum": ["gnu", "intel", "pgi", "cray"]
+        },
         "source": { "type": "string" },
-        "gnu": { "$ref": "#/definitions/compiler" },
-        "intel": { "$ref": "#/definitions/compiler" },
-        "pgi": { "$ref": "#/definitions/compiler" },
-        "cray": { "$ref": "#/definitions/compiler" }
-      },
-      "oneOf": [
-        { "required": ["source","gnu"] },
-        { "required": ["source","intel"] },
-        { "required": ["source","pgi"] },
-        { "required": ["source","cray"] }
-      ],
-      "additionalProperties": false
-    }
-  },
-  "definitions": {
-    "compiler": {
-      "type": "object",
-      "properties": {
+        "exec_args": {"type": "string"},
         "cflags": {"type":  "string"},
         "cxxflags": {"type":  "string"},
         "fflags": {"type":  "string"},
         "cppflags": {"type":  "string"},
-        "ldflags": {"type": "string"},
-        "exec_args": {"type": "string"}
-      }
+        "ldflags": {"type": "string"}
+      },
+      "required": ["source", "name"],
+      "additionalProperties": false
     }
   }
 }

--- a/compiler/compiler-v0.0.1.schema.json
+++ b/compiler/compiler-v0.0.1.schema.json
@@ -25,11 +25,15 @@
       "properties": {
         "source": { "type": "string" },
         "gnu": { "$ref": "#/definitions/compiler" },
-        "intel": { "$ref": "#/definitions/compiler" }
+        "intel": { "$ref": "#/definitions/compiler" },
+        "pgi": { "$ref": "#/definitions/compiler" },
+        "cray": { "$ref": "#/definitions/compiler" }
       },
       "oneOf": [
         { "required": ["source","gnu"] },
-        { "required": ["source","intel"] }
+        { "required": ["source","intel"] },
+        { "required": ["source","pgi"] },
+        { "required": ["source","cray"] }
       ],
       "additionalProperties": false
     }
@@ -39,7 +43,11 @@
       "type": "object",
       "properties": {
         "cflags": {"type":  "string"},
-        "ldflags": {"type": "string"}
+        "cxxflags": {"type":  "string"},
+        "fflags": {"type":  "string"},
+        "cppflags": {"type":  "string"},
+        "ldflags": {"type": "string"},
+        "exec_args": {"type": "string"}
       }
     }
   }

--- a/tests/invalid/compiler/0.0.1/examples.yml
+++ b/tests/invalid/compiler/0.0.1/examples.yml
@@ -7,8 +7,8 @@ missing_type:
    -  "module purge &&  module load intel/18"
   compiler:
     source: src/hello.c
-    intel:
-     cflags: -O1
+    name: intel
+    cflags: "-O1"
 
 missing_compiler:
   type: compiler
@@ -25,8 +25,8 @@ invalid_type_value:
      - "module purge && module load gcc/6.0"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
+    name: gnu
+    cflags: "-O1"
 
 invalid_description_value:
   type: compiler
@@ -36,8 +36,8 @@ invalid_description_value:
      - "module purge && module load gcc/6.0"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
+    name: gnu
+    cflags: "-O1"
 
 invalid_type_module:
   type: compiler
@@ -45,19 +45,19 @@ invalid_type_module:
   module: "module purge && module load gcc/4.0"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
+    name: gnu
+    cflags: "-O1"
 
 module_mismatch_array_items:
   type: compiler
   description: "The module is an array of string items, this test as a mix of numbers and string"
   module:
     - 1
-    - "module purge && module load gcc/4.0"
+    - "module purge && module load intel"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
+    name: intel
+    cflags: "-O1"
 
 missing_source_in_compiler:
   type: compiler
@@ -65,32 +65,29 @@ missing_source_in_compiler:
   module:
   - "module purge && module load gcc/4.0"
   compiler:
-    gnu:
-      cflags: -O1
+    name: gnu
+    cflags: "-O1"
 
 missing_a_compilername_in_compiler:
   type: compiler
-  description: "missing key 'gnu' or 'intel' in compiler object"
+  description: "missing name key in compiler object"
   module:
   - "module purge && module load gcc/4.0"
   compiler:
     source: src/hello.c
 
-
-compiler_required_mismatch:
+compiler_name_type_mismatch:
   type: compiler
-  description: "this test checks required in compiler object we can't specify multiple compiler in same compiler instance"
+  description: "compiler 'name' expects a string but received a list"
   foo: bar
   module:
   - "module purge && module load gcc/4.0"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
-      ldflags: -lm
-    intel:
-      cflags: -O1
-      ldflags: -lm
+    name: ["gnu", "intel"]
+    cflags: "-O1"
+    ldflags: "-lm"
+
 
 test_additionalProperties_compiler:
   type: compiler
@@ -100,9 +97,9 @@ test_additionalProperties_compiler:
   compiler:
     source: src/hello.c
     foo: bar
-    gnu:
-      cflags: -O1
-      ldflags: -lm
+    name: gnu
+    cflags: "-O1"
+    ldflags: "-lm"
 
 test_additionalProperties_main_schema:
   type: compiler
@@ -112,9 +109,9 @@ test_additionalProperties_main_schema:
   - "module purge && module load gcc/4.0"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
-      ldflags: -lm
+    name: gnu
+    cflags: "-O1"
+    ldflags: "-lm"
 
 type_mismatch_exec_args:
   type: compiler
@@ -123,7 +120,7 @@ type_mismatch_exec_args:
   - "module purge && module load gcc/4.0"
   compiler:
     source: src/hello.c
-    gnu:
-      cflags: -O1
-      ldflags: -lm
-      exec_args: 1
+    name: gnu
+    cflags: "-O1"
+    ldflags: "-lm"
+    exec_args: 1

--- a/tests/invalid/compiler/0.0.1/examples.yml
+++ b/tests/invalid/compiler/0.0.1/examples.yml
@@ -115,3 +115,15 @@ test_additionalProperties_main_schema:
     gnu:
       cflags: -O1
       ldflags: -lm
+
+type_mismatch_exec_args:
+  type: compiler
+  description: "type mismatch on exec_args key"
+  module:
+  - "module purge && module load gcc/4.0"
+  compiler:
+    source: src/hello.c
+    gnu:
+      cflags: -O1
+      ldflags: -lm
+      exec_args: 1

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -183,6 +183,11 @@ def test_compiler_schema():
     assert "type" in compiler_definition["properties"]["ldflags"]
     assert compiler_definition["properties"]["ldflags"]["type"] == "string"
 
+    # check exec_args
+    assert "exec_args" in compiler_definition["properties"]
+    assert "type" in compiler_definition["properties"]["exec_args"]
+    assert compiler_definition["properties"]["exec_args"]["type"] == "string"
+
 
 def test_compiler_schema_examples():
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -82,7 +82,6 @@ def test_compiler_schema():
         "properties",
         "additionalProperties",
         "required",
-        "definitions",
     ]
     for field in fields:
         assert field in recipe
@@ -120,73 +119,34 @@ def test_compiler_schema():
     assert "type" in properties["module"]["items"]
     assert properties["module"]["items"]["type"] == "string"
 
+    compiler_keys = ["type", "properties", "required", "additionalProperties"]
+
     # check compiler key
-    for key in ["type", "properties", "oneOf", "additionalProperties"]:
+    for key in compiler_keys:
         assert key in properties["compiler"]
 
     assert properties["compiler"]["type"] == "object"
     assert properties["compiler"]["additionalProperties"] == False
-
     # check compiler properties
+    assert properties["compiler"]["required"] == ["source", "name"]
+
+    string_compiler_keys = [
+        "name",
+        "source",
+        "exec_args",
+        "cflags",
+        "cxxflags",
+        "fflags",
+        "cppflags",
+        "ldflags",
+    ]
     compiler_properties = properties["compiler"]["properties"]
-    assert "source" in compiler_properties
-    assert "type" in compiler_properties["source"]
-    assert compiler_properties["source"]["type"] == "string"
+    for key in string_compiler_keys:
+        assert "type" in compiler_properties[key]
+        assert compiler_properties[key]["type"] == "string"
 
-    # check gnu and intel attribute in compiler properties
-    for key in ["gnu", "intel"]:
-        assert key in compiler_properties
-        assert "$ref" in compiler_properties[key]
-        assert compiler_properties[key]["$ref"] == "#/definitions/compiler"
-
-    # check oneOf attribute in compiler
-    assert properties["compiler"]["oneOf"]
-    for oneOf_item in properties["compiler"]["oneOf"]:
-        assert "required" in oneOf_item
-
-    assert properties["compiler"]["oneOf"][0]["required"] == ["source", "gnu"]
-    assert properties["compiler"]["oneOf"][1]["required"] == ["source", "intel"]
-    assert properties["compiler"]["oneOf"][2]["required"] == ["source", "pgi"]
-    assert properties["compiler"]["oneOf"][3]["required"] == ["source", "cray"]
-
-    # check definition
-    assert "compiler" in recipe["definitions"]
-
-    # compiler definition check
-    compiler_definition = recipe["definitions"]["compiler"]
-    assert "type" in compiler_definition
-    assert compiler_definition["type"] == "object"
-    assert "properties" in compiler_definition
-
-    # check cflags
-    assert "cflags" in compiler_definition["properties"]
-    assert "type" in compiler_definition["properties"]["cflags"]
-    assert compiler_definition["properties"]["cflags"]["type"] == "string"
-
-    # check cxxflags
-    assert "cxxflags" in compiler_definition["properties"]
-    assert "type" in compiler_definition["properties"]["cxxflags"]
-    assert compiler_definition["properties"]["cxxflags"]["type"] == "string"
-
-    # check fflags
-    assert "fflags" in compiler_definition["properties"]
-    assert "type" in compiler_definition["properties"]["fflags"]
-    assert compiler_definition["properties"]["fflags"]["type"] == "string"
-
-    # check fflags
-    assert "cppflags" in compiler_definition["properties"]
-    assert "type" in compiler_definition["properties"]["cppflags"]
-    assert compiler_definition["properties"]["cppflags"]["type"] == "string"
-
-    # check ldflags
-    assert "ldflags" in compiler_definition["properties"]
-    assert "type" in compiler_definition["properties"]["ldflags"]
-    assert compiler_definition["properties"]["ldflags"]["type"] == "string"
-
-    # check exec_args
-    assert "exec_args" in compiler_definition["properties"]
-    assert "type" in compiler_definition["properties"]["exec_args"]
-    assert compiler_definition["properties"]["exec_args"]["type"] == "string"
+    "enum" in compiler_properties["name"]
+    compiler_properties["name"]["enum"] == ["gnu", "intel", "pgi", "cray"]
 
 
 def test_compiler_schema_examples():

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -141,10 +141,13 @@ def test_compiler_schema():
 
     # check oneOf attribute in compiler
     assert properties["compiler"]["oneOf"]
-    assert "required" in properties["compiler"]["oneOf"][0]
-    assert "required" in properties["compiler"]["oneOf"][1]
+    for oneOf_item in properties["compiler"]["oneOf"]:
+        assert "required" in oneOf_item
+
     assert properties["compiler"]["oneOf"][0]["required"] == ["source", "gnu"]
     assert properties["compiler"]["oneOf"][1]["required"] == ["source", "intel"]
+    assert properties["compiler"]["oneOf"][2]["required"] == ["source", "pgi"]
+    assert properties["compiler"]["oneOf"][3]["required"] == ["source", "cray"]
 
     # check definition
     assert "compiler" in recipe["definitions"]
@@ -154,9 +157,28 @@ def test_compiler_schema():
     assert "type" in compiler_definition
     assert compiler_definition["type"] == "object"
     assert "properties" in compiler_definition
+
+    # check cflags
     assert "cflags" in compiler_definition["properties"]
     assert "type" in compiler_definition["properties"]["cflags"]
     assert compiler_definition["properties"]["cflags"]["type"] == "string"
+
+    # check cxxflags
+    assert "cxxflags" in compiler_definition["properties"]
+    assert "type" in compiler_definition["properties"]["cxxflags"]
+    assert compiler_definition["properties"]["cxxflags"]["type"] == "string"
+
+    # check fflags
+    assert "fflags" in compiler_definition["properties"]
+    assert "type" in compiler_definition["properties"]["fflags"]
+    assert compiler_definition["properties"]["fflags"]["type"] == "string"
+
+    # check fflags
+    assert "cppflags" in compiler_definition["properties"]
+    assert "type" in compiler_definition["properties"]["cppflags"]
+    assert compiler_definition["properties"]["cppflags"]["type"] == "string"
+
+    # check ldflags
     assert "ldflags" in compiler_definition["properties"]
     assert "type" in compiler_definition["properties"]["ldflags"]
     assert compiler_definition["properties"]["ldflags"]["type"] == "string"

--- a/tests/valid/compiler/0.0.1/examples.yml
+++ b/tests/valid/compiler/0.0.1/examples.yml
@@ -1,14 +1,15 @@
 version: 0.0.1
 gnu_example:
   type: compiler
-  description: "gnu example using cflags"
+  description: "gnu example using cflags, exec_args"
   module:
      - "module purge && module load gcc/4.0"
      - "module purge && module load gcc/6.0"
   compiler:
+    name: gnu
     source: src/hello.c
-    gnu:
-      cflags: -O1
+    cflags: "-O1"
+    exec_args: "1 2 3"
 
 intel_example:
   type: compiler
@@ -17,9 +18,9 @@ intel_example:
     -  "module purge &&  module load intel/17"
     -  "module purge &&  module load intel/18"
   compiler:
+    name: intel
     source: src/hello.c
-    intel:
-     cflags: -O1
+    cflags: "-O1"
 
 pgi_example:
   type: compiler
@@ -28,15 +29,16 @@ pgi_example:
     -  "module purge &&  module load pgi"
   compiler:
     source: src/hello.cpp
-    pgi:
-     cxxflags: -O1
-     ldflags: -lm
-     exec_args: hello world
+    name: pgi
+    cxxflags: "-O1"
+    ldflags: "-lm"
+    exec_args: hello world
 
 cray_example:
   type: compiler
-  description: "cray example using fflags"
+  description: "cray example using fflags and cppflags"
   compiler:
+    name: cray
     source: src/hello.f90
-    cray:
-     fflags: -O1
+    fflags: "-O1"
+    cppflags: "-DFOO"

--- a/tests/valid/compiler/0.0.1/examples.yml
+++ b/tests/valid/compiler/0.0.1/examples.yml
@@ -18,3 +18,20 @@ hello_world_intel:
     source: src/hello.c
     intel:
      cflags: -O1
+
+pgi_example:
+  type: compiler
+  module:
+    -  "module purge &&  module load pgi"
+  compiler:
+    source: src/hello.c
+    pgi:
+     cflags: -O1
+     ldflags: -lm
+
+cray_example:
+  type: compiler
+  compiler:
+    source: src/hello.cpp
+    cray:
+     cxxflags: -O1

--- a/tests/valid/compiler/0.0.1/examples.yml
+++ b/tests/valid/compiler/0.0.1/examples.yml
@@ -1,6 +1,7 @@
 version: 0.0.1
-hello_world_gnu:
+gnu_example:
   type: compiler
+  description: "gnu example using cflags"
   module:
      - "module purge && module load gcc/4.0"
      - "module purge && module load gcc/6.0"
@@ -9,8 +10,9 @@ hello_world_gnu:
     gnu:
       cflags: -O1
 
-hello_world_intel:
+intel_example:
   type: compiler
+  description: "intel example using cflags"
   module:
     -  "module purge &&  module load intel/17"
     -  "module purge &&  module load intel/18"
@@ -21,17 +23,20 @@ hello_world_intel:
 
 pgi_example:
   type: compiler
+  description: "pgi example using cxxflags, ldflags, and exec_args key"
   module:
     -  "module purge &&  module load pgi"
   compiler:
-    source: src/hello.c
+    source: src/hello.cpp
     pgi:
-     cflags: -O1
+     cxxflags: -O1
      ldflags: -lm
+     exec_args: hello world
 
 cray_example:
   type: compiler
+  description: "cray example using fflags"
   compiler:
-    source: src/hello.cpp
+    source: src/hello.f90
     cray:
-     cxxflags: -O1
+     fflags: -O1


### PR DESCRIPTION
Summary
-----------

- add ``pgi`` and ``cray`` compiler names
- add flags ``cxxflags``, ``fflags``, ``cppflags``, ``exec_flags``.
- Fix assertion in compiler schema check to account for change to schema and add Valid examples for pgi and cray Buildspec

This PR is in response to integration of compiler schema into buildtest see https://github.com/buildtesters/buildtest/pull/300